### PR TITLE
change how crop decided as its not always passed in the image data url

### DIFF
--- a/pbc-cloudinary-integration.php
+++ b/pbc-cloudinary-integration.php
@@ -188,7 +188,8 @@ class Cloudinary {
 
     public function filter_attachment_src($image, $attachment_id, $size, $icon) {
         $extra_options = '';
-        list( $src, $width, $height, $crop ) = $image;
+        list( $src, $width, $height) = $image;
+		$crop = (isset($image[3]) && $image[3]) ?? false;
 
         if(is_array($size)){
             list( $size_w, $size_h ) = $size;


### PR DESCRIPTION
```php
list( $src, $width, $height, $crop ) = $image;
``` 

This line is causng an undefined array index '3' warning. Index at 3 would be `$crop`, its not always defined in the $image array passed to the function.

```php
list( $src, $width, $height) = $image;
$crop = (isset($image[3]) && $image[3]) ?? false;
``` 

Changing to look for a crop if index 3 is set and is not falsey, otherwise set false